### PR TITLE
Feature/Add Missing Blog and Organization Schemas and data relation

### DIFF
--- a/drizzle/0001_dark_bedlam.sql
+++ b/drizzle/0001_dark_bedlam.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `blog` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	`organization_id` text,
+	`author` text NOT NULL,
+	`title` text NOT NULL,
+	`slug` text NOT NULL,
+	`image` text NOT NULL,
+	`body` text NOT NULL,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`likes` integer DEFAULT 0 NOT NULL,
+	`status` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`author`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `organization` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	`name` text NOT NULL,
+	`subdomain` text NOT NULL,
+	`custom_domain` text NOT NULL,
+	`settings` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+ALTER TABLE `user` ADD `role` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `user` ADD `organization_id` text REFERENCES organization(id);

--- a/drizzle/0002_shiny_jigsaw.sql
+++ b/drizzle/0002_shiny_jigsaw.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_blog` (
+	`id` text PRIMARY KEY NOT NULL,
+	`created_at` integer,
+	`updated_at` integer,
+	`organization_id` text,
+	`author_id` text NOT NULL,
+	`title` text NOT NULL,
+	`slug` text NOT NULL,
+	`image` text NOT NULL,
+	`body` text NOT NULL,
+	`tags` text DEFAULT '[]' NOT NULL,
+	`likes` integer DEFAULT 0 NOT NULL,
+	`status` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`author_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_blog`("id", "created_at", "updated_at", "organization_id", "author_id", "title", "slug", "image", "body", "tags", "likes", "status") SELECT "id", "created_at", "updated_at", "organization_id", "author_id", "title", "slug", "image", "body", "tags", "likes", "status" FROM `blog`;--> statement-breakpoint
+DROP TABLE `blog`;--> statement-breakpoint
+ALTER TABLE `__new_blog` RENAME TO `blog`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,332 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "171d782e-8117-4bd8-8afd-637578147fd3",
+  "prevId": "3f85e3e7-5ea4-41bc-ac1c-fe115c23c3e8",
+  "tables": {
+    "blog": {
+      "name": "blog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_organization_id_organization_id_fk": {
+          "name": "blog_organization_id_organization_id_fk",
+          "tableFrom": "blog",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_author_user_id_fk": {
+          "name": "blog_author_user_id_fk",
+          "tableFrom": "blog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_id_organization_id_fk": {
+          "name": "user_organization_id_organization_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,334 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "26e98e86-dd08-49ee-bff2-d3aa30d14cb7",
+  "prevId": "171d782e-8117-4bd8-8afd-637578147fd3",
+  "tables": {
+    "blog": {
+      "name": "blog",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_organization_id_organization_id_fk": {
+          "name": "blog_organization_id_organization_id_fk",
+          "tableFrom": "blog",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_author_id_user_id_fk": {
+          "name": "blog_author_id_user_id_fk",
+          "tableFrom": "blog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "custom_domain": {
+          "name": "custom_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_id_organization_id_fk": {
+          "name": "user_organization_id_organization_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {
+      "\"blog\".\"author\"": "\"blog\".\"author_id\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1735894140108,
       "tag": "0001_dark_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1735896835143,
+      "tag": "0002_shiny_jigsaw",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1735381295244,
       "tag": "0000_glamorous_inhumans",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1735894140108,
+      "tag": "0001_dark_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/relation/blog-relations.ts
+++ b/src/db/relation/blog-relations.ts
@@ -5,7 +5,7 @@ import { relations } from "drizzle-orm";
 
 export const blogRelation = relations(BlogTable, ({ one } ) => ({
   author: one(UserTable, {
-    fields: [BlogTable.author],
+    fields: [BlogTable.authorId],
     references: [UserTable.id]
   }),
   organizationId: one(OrganizationTable, {

--- a/src/db/relation/blog-relations.ts
+++ b/src/db/relation/blog-relations.ts
@@ -1,0 +1,15 @@
+import { BlogTable } from "db/schema/blog";
+import { OrganizationTable } from "db/schema/organization";
+import { UserTable } from "db/schema/user";
+import { relations } from "drizzle-orm";
+
+export const blogRelation = relations(BlogTable, ({ one } ) => ({
+  author: one(UserTable, {
+    fields: [BlogTable.author],
+    references: [UserTable.id]
+  }),
+  organizationId: one(OrganizationTable, {
+    fields: [BlogTable.organizationId],
+    references: [OrganizationTable.id]
+  })
+}));

--- a/src/db/relation/user-relations.ts
+++ b/src/db/relation/user-relations.ts
@@ -1,0 +1,12 @@
+import { BlogTable } from "db/schema/blog";
+import { OrganizationTable } from "db/schema/organization";
+import { UserTable } from "db/schema/user";
+import { relations } from "drizzle-orm";
+
+export const userRelation = relations(UserTable, ({ one, many }) => ({
+  organizationId: one(OrganizationTable, {
+    fields: [UserTable.organizationId],
+    references: [OrganizationTable.id]
+  }),
+  blogs: many(BlogTable)
+}));

--- a/src/db/schema/blog.ts
+++ b/src/db/schema/blog.ts
@@ -1,0 +1,18 @@
+import { baseTable } from "db/base";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { OrganizationTable } from "./organization";
+import { UserTable } from "./user";
+import { sql } from "drizzle-orm";
+
+export const BlogTable = sqliteTable("blog", {
+  ...baseTable,
+  organizationId: text().references(() => OrganizationTable.id),
+  author: text().references(() => UserTable.id).notNull(),
+  title: text().notNull(),
+  slug: text().notNull(),
+  image: text().notNull(),
+  body: text().notNull(),
+  tags: text({ mode: "json" }).notNull().$type<string[]>().default(sql`'[]'`),
+  likes: integer().notNull().default(0),
+  status: text({ enum: ["draft", "published"]}).notNull()
+})

--- a/src/db/schema/blog.ts
+++ b/src/db/schema/blog.ts
@@ -7,7 +7,7 @@ import { sql } from "drizzle-orm";
 export const BlogTable = sqliteTable("blog", {
   ...baseTable,
   organizationId: text().references(() => OrganizationTable.id),
-  author: text().references(() => UserTable.id).notNull(),
+  authorId: text().references(() => UserTable.id).notNull(),
   title: text().notNull(),
   slug: text().notNull(),
   image: text().notNull(),

--- a/src/db/schema/organization.ts
+++ b/src/db/schema/organization.ts
@@ -1,0 +1,16 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { baseTable } from '../base';
+
+export const OrganizationTable = sqliteTable("organization", {
+  ...baseTable,
+  name: text().notNull(),
+  subdomain: text().notNull(),
+  customDomain: text().notNull(),
+  settings: text({ mode: "json"}).$type<
+    {
+      theme: string,
+      logo: string,
+      description: string
+    }
+  >().notNull()
+})

--- a/src/db/schema/user.ts
+++ b/src/db/schema/user.ts
@@ -1,7 +1,7 @@
 import type { InferSelectModel } from "drizzle-orm";
 import { sqliteTable, text } from "drizzle-orm/sqlite-core";
-
 import { baseTable } from "../base";
+import { OrganizationTable } from "./organization";
 
 export const UserTable = sqliteTable("user", {
   ...baseTable,
@@ -9,6 +9,8 @@ export const UserTable = sqliteTable("user", {
   lastName: text(),
   email: text(),
   passwordHash: text(),
+  role: text({ enum: ["admin", "editor"] }).notNull(),
+  organizationId: text().references(() => OrganizationTable.id)
 });
 
 export type UserInterface = InferSelectModel<typeof UserTable>;


### PR DESCRIPTION
## Related Issue

Closes #24

## Changes

- Added Missing Schemas of Blog and Organization in the drizzle ORM setup
- Defined references between blog, users and orgs

<sub><a href="https://huly.app/guest/keizerworks?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc3YTcyOGYxNDRmNTg1YWU1MjRiODciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Incta2VpemVyd29ya3Mta2VpemVyd29ya3MtNjc2YmIzYzQtNTg1NDc1Mzg4My00NDc3M2YifQ.CBdMr8SSQVEMDhaiPF6VPDvLhqSTEL_RgTxERIFvLM4">Huly&reg;: <b>K_BLO-28</b></a></sub>